### PR TITLE
Add +immutant profile

### DIFF
--- a/src/leiningen/new/immutant.clj
+++ b/src/leiningen/new/immutant.clj
@@ -1,0 +1,10 @@
+(ns leiningen.new.immutant
+  (:require [leiningen.new.common :refer :all]))
+
+(defn immutant-features [[assets options :as state]]
+  (if (some #{"+immutant"} (:features options))
+    [(into assets [["src/<<sanitized>>/core.clj" "immutant/core.clj"]])
+     (-> options
+         (append-options :dependencies [['org.immutant/web "2.0.0-beta2"]])
+         (assoc :main (symbol (str (:project-ns options) ".core"))))]
+    state))

--- a/src/leiningen/new/luminus.clj
+++ b/src/leiningen/new/luminus.clj
@@ -13,6 +13,7 @@
             [leiningen.new.cljs :refer [cljs-features]]
             [leiningen.new.cucumber :refer [cucumber-features]]
             [leiningen.new.http-kit :refer [http-kit-features]]
+            [leiningen.new.immutant :refer [immutant-features]]
             [leiningen.new.site :refer [site-features]])
   (:import java.io.File))
 
@@ -68,7 +69,8 @@
               cucumber-features
               site-features
               cljs-features
-              http-kit-features)]
+              http-kit-features
+              immutant-features)]
       (render-assets assets (format-options options)))))
 
 (defn format-features [features]
@@ -79,7 +81,7 @@
   [name & feature-params]
   (let [supported-features #{"+cljs" "+site" "+h2" "+postgres"
                              "+dailycred" "+mysql" "+http-kit"
-                             "+cucumber" "+mongodb" "+auth"}
+                             "+cucumber" "+mongodb" "+auth" "+immutant"}
         options {:name       (project-name name)
                  :selmer-renderer render-template
                  :min-lein-version "2.0.0"

--- a/src/leiningen/new/luminus/immutant/core.clj
+++ b/src/leiningen/new/luminus/immutant/core.clj
@@ -1,0 +1,27 @@
+(ns <<project-ns>>.core
+  (:require
+    [<<name>>.handler :refer [app]]
+    [immutant.web :as immutant]
+    [taoensso.timbre :as timbre])
+  (:gen-class))
+
+(defonce server (atom nil))
+
+(defn start-server [args]
+  "Args should be a flat sequence of key/value pairs corresponding to
+  options accepted by `immutant.web/run`. Keys may be keywords or
+  strings, but the latter should not include the colon prefix. If the
+  -dev option is present, `immutant.web/run-dmc` will be used"
+  (let [options (remove #{"-dev"} args)]
+    (reset! server
+      (if (some #{"-dev"} args)
+        (immutant/run-dmc app options)
+        (immutant/run app options)))))
+
+(defn stop-server []
+  (immutant/stop @server))
+
+(defn -main [& args]
+  "e.g. lein run -dev port 3000"
+  (start-server args)
+  (timbre/info "server started on port:" (:port @server)))


### PR DESCRIPTION
This is pretty much modeled on the `+http-kit` profile, but exposes all the options supported by [immutant.web/run](http://immutant.org/documentation/current/apidoc/immutant.web.html#var-run) since it can take either a map or a sequence, and the keys can be either keywords or strings, so you could do something like this:
```
$ lein run port 80 virtual-host "my.host.com"
```
Presence of `-dev` among the args will trigger the use of [run-dmc](http://immutant.org/documentation/current/apidoc/immutant.web.html#var-run-dmc) instead of `run`, e.g.
```
$ lein run -dev port 3000
```
That'll fire up your browser and enable code-reloading.